### PR TITLE
add support for NULL keys

### DIFF
--- a/ksnap/partition.py
+++ b/ksnap/partition.py
@@ -34,7 +34,7 @@ class Partition:
         create_table_query = (
             "CREATE TABLE IF NOT EXISTS data "
             "(offset INTEGER PRIMARY KEY, "
-            "key BLOB NOT NULL, "
+            "key BLOB, "
             "message BLOB, "
             "timestamp INTEGER, "
             "headers TEXT)"


### PR DESCRIPTION
Hi there

I noticed that ksnap failes when encountering a message with NULL as the key. The restriction for message-keys to have to be non-null doesn't make sense. Kafka messages without a key are perfectly fine in certain use cases and should be backed up correctly.