### PR TITLE
Saved topic to disk after each iteration.

### DIFF
--- a/ksnap/data_flow.py
+++ b/ksnap/data_flow.py
@@ -46,8 +46,7 @@ class DataFlowManager:
         offsets = offset_manager.offsets
         return (offsets, partitions)
 
-    def write(self, offsets: List[Offset],
-              partitions: List[Partition]):
+    def write_partitions(self, partitions: List[Partition]):
         os.makedirs(self.partition_file_dir, exist_ok=True)
         logger.info(f'Write {len(partitions)} partitions '
                     f'to {self.partition_file_dir}')
@@ -60,5 +59,12 @@ class DataFlowManager:
                 f'from topic: {partition.topic} '
                 f'partition: {partition.name} to disk')
             partition.to_file(file_path)
+
+    def write_offsets(self, offsets: List[Offset]):
+        os.makedirs(self.partition_file_dir, exist_ok=True)
         logger.info(f'Write {len(offsets)} consumer group offsets to disk')
         OffsetManager(offsets).to_file(self.offset_file_path)
+
+    def write(self, offsets: List[Offset], partitions: List[Partition]):
+        self.write_partitions(partitions)
+        self.write_offsets(offsets)

--- a/ksnap/reader/base.py
+++ b/ksnap/reader/base.py
@@ -44,7 +44,7 @@ class KafkaReader(ABC):
         pass
 
     @abstractmethod
-    def read(self):
+    def read(self, timeout: int = 0):
         pass
 
     @abstractmethod

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ for item in requirements:
 
 setup(
     name='ksnap',
-    version='2.0.5',
+    version='2.1.0',
     packages=find_packages(),
     python_requires='>=3.6, <4',
     install_requires=requires,


### PR DESCRIPTION
This changes the backup process to save the data after reading each individual topic, instead of waiting to read all messages from all topics before writing them to disk. 

This is to reduce the memory usage of the backup process when it involves a large amount of topics.